### PR TITLE
Unicode + MySQL fix

### DIFF
--- a/django_mailer/engine.py
+++ b/django_mailer/engine.py
@@ -152,6 +152,8 @@ def send_message(queued_message, smtp_connection=None, blacklist=None,
     message is not deleted.
     
     """
+    from django.utils.encoding import smart_str
+    
     message = queued_message.message
     if smtp_connection is None:
         smtp_connection = SMTPConnection()
@@ -176,7 +178,7 @@ def send_message(queued_message, smtp_connection=None, blacklist=None,
             opened_connection = smtp_connection.open()
             smtp_connection.connection.sendmail(message.from_address,
                                                 [message.to_address],
-                                                message.encoded_message)
+                                                smart_str(message.encoded_message))
             queued_message.delete()
             result = constants.RESULT_SENT
         except (SocketError, smtplib.SMTPSenderRefused,


### PR DESCRIPTION
Hey Chris, we (Track) ran into an issue sending our alerts and after quite a lot of digging through code I finally fixed it.  The problem arose from having unicode characters in the title of an article, and therefore in the body of an email.

This patch doesn't solve the fundamental problem that you can save a TextField as '\xe2\x80\x93' and then later MySQL gives you back u'\u2013', but it's a cheap workaround.

Hope you guys at LL are all doing well.

Rich
