### PR TITLE
South migrations and custom error handlers

### DIFF
--- a/django_mailer/engine.py
+++ b/django_mailer/engine.py
@@ -181,7 +181,7 @@ def send_queued_message(queued_message, smtp_connection=None, blacklist=None,
             result = constants.RESULT_SENT
         except Exception, err:
             if settings.CUSTOM_ERROR_HANDLER:
-                result = settings.CUSTOM_ERROR_HANDLER(err)
+                result = settings.CUSTOM_ERROR_HANDLER(queued_message, err)
             elif isinstance(err, (SocketError,
                                   smtplib.SMTPSenderRefused,
                                   smtplib.SMTPRecipientsRefused,
@@ -229,7 +229,7 @@ def send_message(email_message, smtp_connection=None):
         result = constants.RESULT_SENT
     except Exception, err:
         if settings.CUSTOM_ERROR_HANDLER:
-            result = settings.CUSTOM_ERROR_HANDLER(err)
+            result = settings.CUSTOM_ERROR_HANDLER(email_message, err)
         elif isinstance(err, (SocketError,
                               smtplib.SMTPSenderRefused,
                               smtplib.SMTPRecipientsRefused,

--- a/django_mailer/migrations/0001_initial.py
+++ b/django_mailer/migrations/0001_initial.py
@@ -1,0 +1,102 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'Message'
+        db.create_table('django_mailer_message', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('to_address', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('from_address', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('subject', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('encoded_message', self.gf('django.db.models.fields.TextField')()),
+            ('date_created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+        ))
+        db.send_create_signal('django_mailer', ['Message'])
+
+        # Adding model 'QueuedMessage'
+        db.create_table('django_mailer_queuedmessage', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('message', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['django_mailer.Message'], unique=True)),
+            ('priority', self.gf('django.db.models.fields.PositiveSmallIntegerField')(default=3)),
+            ('deferred', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('retries', self.gf('django.db.models.fields.PositiveIntegerField')(default=0)),
+            ('date_queued', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+        ))
+        db.send_create_signal('django_mailer', ['QueuedMessage'])
+
+        # Adding model 'Blacklist'
+        db.create_table('django_mailer_blacklist', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('email', self.gf('django.db.models.fields.EmailField')(max_length=200)),
+            ('date_added', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+        ))
+        db.send_create_signal('django_mailer', ['Blacklist'])
+
+        # Adding model 'Log'
+        db.create_table('django_mailer_log', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('message', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['django_mailer.Message'])),
+            ('result', self.gf('django.db.models.fields.PositiveSmallIntegerField')()),
+            ('date', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('log_message', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('django_mailer', ['Log'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'Message'
+        db.delete_table('django_mailer_message')
+
+        # Deleting model 'QueuedMessage'
+        db.delete_table('django_mailer_queuedmessage')
+
+        # Deleting model 'Blacklist'
+        db.delete_table('django_mailer_blacklist')
+
+        # Deleting model 'Log'
+        db.delete_table('django_mailer_log')
+
+
+    models = {
+        'django_mailer.blacklist': {
+            'Meta': {'ordering': "('-date_added',)", 'object_name': 'Blacklist'},
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'django_mailer.log': {
+            'Meta': {'ordering': "('-date',)", 'object_name': 'Log'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'log_message': ('django.db.models.fields.TextField', [], {}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['django_mailer.Message']"}),
+            'result': ('django.db.models.fields.PositiveSmallIntegerField', [], {})
+        },
+        'django_mailer.message': {
+            'Meta': {'ordering': "('date_created',)", 'object_name': 'Message'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'encoded_message': ('django.db.models.fields.TextField', [], {}),
+            'from_address': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'to_address': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        'django_mailer.queuedmessage': {
+            'Meta': {'ordering': "('priority', 'date_queued')", 'object_name': 'QueuedMessage'},
+            'date_queued': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'deferred': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['django_mailer.Message']", 'unique': 'True'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '3'}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['django_mailer']

--- a/django_mailer/settings.py
+++ b/django_mailer/settings.py
@@ -23,3 +23,8 @@ LOCK_WAIT_TIMEOUT = max(getattr(settings, "MAILER_LOCK_WAIT_TIMEOUT", 0), 0)
 # An optional alternate lock path, potentially useful if you have multiple
 # projects running on the same server.
 LOCK_PATH = getattr(settings, "MAILER_LOCK_PATH", None)
+
+# An optional custom error handler. This is useful if you are hooking in
+# to backends other than SMTP and want to be able to defer messages based
+# on non-SMTP exceptions.
+CUSTOM_ERROR_HANDLER = getattr(settings, "MAILER_ERROR_HANDLER", None)

--- a/django_mailer/tests/__init__.py
+++ b/django_mailer/tests/__init__.py
@@ -1,3 +1,3 @@
 from django_mailer.tests.commands import TestCommands
-from django_mailer.tests.engine import LockTest #COULD DROP THIS TEST
+from django_mailer.tests.engine import LockTest, TestErrorHandling #COULD DROP THIS TEST
 from django_mailer.tests.backend import TestBackend

--- a/django_mailer/tests/base.py
+++ b/django_mailer/tests/base.py
@@ -1,6 +1,6 @@
 from django.core import mail
-from django.test import TestCase
-from django_mailer import queue_email_message
+from django.test import TestCase, TransactionTestCase
+from django_mailer import queue_email_message, settings
 try:
     from django.core.mail import backends
     EMAIL_BACKEND_SUPPORT = True
@@ -12,17 +12,31 @@ class FakeConnection(object):
     """
     A fake SMTP connection which diverts emails to the test buffer rather than
     sending.
-    
+
+    To override how this method is handled you can call 
+    FakeConnection.set_overrides with a list of overrides. Upon each call to
+    sendmail the 1st item in the overrides will be popped off the list and
+    called as if it were being called instead of sendmail. Once the list is 
+    empty the default behaviour of this fake connection will take over.
     """
+    @staticmethod
+    def set_overrides(callbacks):
+        FakeConnection._overrides = callbacks
+
     def sendmail(self, *args, **kwargs):
         """
         Divert an email to the test buffer.
         
         """
-        #FUTURE: the EmailMessage attributes could be found by introspecting
-        # the encoded message.
-        message = mail.EmailMessage('SUBJECT', 'BODY', 'FROM', ['TO'])
-        mail.outbox.append(message)
+        if FakeConnection._overrides:
+            callback = FakeConnection._overrides.pop(0)
+            callback(*args, **kwargs)
+        else:
+            #FUTURE: the EmailMessage attributes could be found by introspecting
+            # the encoded message.
+            message = mail.EmailMessage('SUBJECT', 'BODY', 'FROM', ['TO'])
+            mail.outbox.append(message)
+FakeConnection._overrides = []
 
 
 if EMAIL_BACKEND_SUPPORT:
@@ -40,7 +54,7 @@ if EMAIL_BACKEND_SUPPORT:
             pass
         
 
-class MailerTestCase(TestCase):
+class MailerTestCase(TransactionTestCase):
     """
     A base class for Django Mailer test cases which diverts emails to the test
     buffer and provides some helper methods.
@@ -50,11 +64,13 @@ class MailerTestCase(TestCase):
         if EMAIL_BACKEND_SUPPORT:
             self.saved_email_backend = backends.smtp.EmailBackend
             backends.smtp.EmailBackend = TestEmailBackend
+            self.connection = TestEmailBackend()
         else:
             connection = mail.SMTPConnection
             if hasattr(connection, 'connection'):
                 connection.pretest_connection = connection.connection
             connection.connection = FakeConnection()
+            self.connection = connection
 
     def tearDown(self):
         if EMAIL_BACKEND_SUPPORT:
@@ -64,6 +80,9 @@ class MailerTestCase(TestCase):
             if hasattr(connection, 'pretest_connection'):
                 connection.connection = connection.pretest_connection
 
+        FakeConnection.set_overrides([])
+        settings.CUSTOM_ERROR_HANDLER = None
+    
     def queue_message(self, subject='test', message='a test message',
                       from_email='sender@djangomailer',
                       recipient_list=['recipient@djangomailer'],

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -60,3 +60,12 @@ place.
 
 The default value is ``-1`` which means to never wait for the lock to be
 available.
+
+MAILER_ERROR_HANDLER
+--------------------
+An optional custom error handler. This is useful if you are hooking in
+to backends other than SMTP and want to be able to defer messages based
+on non-SMTP exceptions.
+
+The format of the callback is a function that takes one argument: the 
+exception thrown by sendmail.


### PR DESCRIPTION
This adds an option to add a custom error handler. We need this so that we can use Amazon SES and handle the errors from that (it's not SMTP so it doesn't throw out SMTP errors)
